### PR TITLE
Create and manage independent html apps

### DIFF
--- a/src/data/apps.ts
+++ b/src/data/apps.ts
@@ -13,13 +13,12 @@ export type HtmlAppMeta = {
  * This runs at build/runtime via Vite's import.meta.glob, bundling small JSON metadata.
  */
 export function getHtmlApps(): HtmlAppMeta[] {
-  const modules = import.meta.glob('../apps/*/meta.json', { eager: true }) as Record<string, any>
+  const modules = import.meta.glob('../../apps/*/meta.json', { eager: true }) as Record<string, any>
 
   const apps: HtmlAppMeta[] = []
-  const slugRegex = /\.\.\/apps\/([^/]+)\/meta\.json$/
-
-  for (const [path, mod] of Object.entries(modules)) {
-    const match = path.match(slugRegex)
+  for (const [pathKey, mod] of Object.entries(modules)) {
+    const normalizedPath = pathKey.replace(/\\/g, '/')
+    const match = normalizedPath.match(/(?:^|\/)apps\/([^/]+)\/meta\.json$/)
     if (!match) continue
     const slug = match[1]
     const raw = (mod && (mod.default ?? mod)) || {}


### PR DESCRIPTION
Fixes independent HTML application detection.

The previous `import.meta.glob` path was incorrect relative to `src/data/apps.ts`, preventing `meta.json` files from being discovered. Additionally, the slug extraction regex was brittle, failing to correctly parse paths and identify the application's slug, leading to applications not appearing in the list.

---
<a href="https://cursor.com/background-agent?bcId=bc-89dd9669-2316-4fda-adc0-8be7af32f863">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-89dd9669-2316-4fda-adc0-8be7af32f863">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

