### PR TITLE
Fix homepage redirect for github pages

### DIFF
--- a/apps/hello/index.html
+++ b/apps/hello/index.html
@@ -12,7 +12,7 @@
       <header class="sticky top-0 z-30 border-b border-mech-edge/70 backdrop-blur bg-mech-bg/70 -mx-4 px-4 py-3">
         <div class="flex items-center justify-between">
           <a class="font-semibold tracking-wider hover:text-black" href="/index.html">Mecha Tools</a>
-          <a class="inline-flex items-center gap-2 px-3 py-2 rounded-md border border-mech-edge bg-white hover:bg-neutral-50 text-mech-text transition-colors" href="/index.html#">返回首页</a>
+          <a class="inline-flex items-center gap-2 px-3 py-2 rounded-md border border-mech-edge bg-white hover:bg-neutral-50 text-mech-text transition-colors" href="https://tobenot.top/Tobenot-Web-Tools/">返回首页</a>
         </div>
       </header>
 


### PR DESCRIPTION
Update 'Return to Home' button link to correctly navigate on GitHub Pages.

---
<a href="https://cursor.com/background-agent?bcId=bc-a6876781-b1ee-4b59-a420-379a63642601">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a6876781-b1ee-4b59-a420-379a63642601">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

