### PR TITLE
feat: 大字展示板工具

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ import { UrlCodecTool } from './tools/url-codec/UrlCodecTool'
 import { RegexTesterTool } from './tools/regex-tester/RegexTesterTool'
 import { TextDiffTool } from './tools/text-diff/TextDiffTool'
 import { QrCodeTool } from './tools/qrcode/QrCodeTool'
+import { BigTextTool } from './tools/big-text/BigTextTool'
 import { getHashLocation } from './utils/hash'
 import { setFavicon } from './utils/favicon'
 import { recordToolVisit } from './utils/recent'
@@ -42,8 +43,11 @@ export default function App() {
     }
   }, [route.path])
 
+  const fullPagePaths = ['markdown-reader', 'big-text']
+  const isFullPage = fullPagePaths.includes(route.path)
+
   return (
-    <Layout hideFooter={route.path === 'markdown-reader'}>
+    <Layout hideFooter={isFullPage}>
       <Header />
       <DomainMigrationBanner />
       <CommandPalette />
@@ -54,7 +58,14 @@ export default function App() {
           </ErrorBoundary>
         </main>
       )}
-      <main className={`w-full px-6 pb-16 pt-8${route.path === 'markdown-reader' ? ' hidden' : ''}`}>
+      {route.path === 'big-text' && (
+        <main className="w-full" style={{ height: 'calc(100vh - 66px)' }}>
+          <ErrorBoundary>
+            <BigTextTool />
+          </ErrorBoundary>
+        </main>
+      )}
+      <main className={`w-full px-6 pb-16 pt-8${isFullPage ? ' hidden' : ''}`}>
         {route.path === '' && <Home />}
         {route.path === 'calendar' && <ErrorBoundary><CalendarTool /></ErrorBoundary>}
         {route.path === 'prompt-gallery' && <ErrorBoundary><PromptGalleryTool /></ErrorBoundary>}

--- a/src/data/routes.ts
+++ b/src/data/routes.ts
@@ -112,6 +112,16 @@ export const tools: ToolDef[] = [
     href: '#qrcode'
   },
   {
+    id: 'big-text',
+    title: '大字展示板',
+    description: '输入文字即时大字展示，适合需要辅助沟通的场景',
+    emoji: '🔤',
+    version: 'v1.0',
+    category: 'app',
+    href: '#big-text',
+    tags: ['沟通', '无障碍', '展示']
+  },
+  {
     id: 'changelog',
     title: '更新日志',
     description: '查看项目更新记录',
@@ -135,6 +145,7 @@ export const pageTitleMap: Record<string, string> = {
   'regex-tester': '正则测试器 | Mecha Tools',
   'text-diff': '文本 Diff 对比 | Mecha Tools',
   'qrcode': '二维码生成 | Mecha Tools',
+  'big-text': '大字展示板 | Mecha Tools',
   changelog: '更新日志 | Mecha Tools',
   about: '关于与设计 | Mecha Tools'
 }

--- a/src/tools/big-text/BigTextTool.tsx
+++ b/src/tools/big-text/BigTextTool.tsx
@@ -1,0 +1,163 @@
+import { useEffect, useRef, useState } from 'react'
+
+const FONT_SIZES = [80, 120, 160, 200, 240] as const
+const DEFAULT_FONT_SIZE = 160
+
+const QUICK_PHRASES = [
+	'谢谢',
+	'请等一下',
+	'我需要帮助',
+	'好的',
+	'不',
+	'疼',
+	'水',
+	'厕所',
+]
+
+export function BigTextTool() {
+	const [text, setText] = useState('')
+	const [fontSize, setFontSize] = useState(DEFAULT_FONT_SIZE)
+	const [darkMode, setDarkMode] = useState(true)
+	const [isFullscreen, setIsFullscreen] = useState(false)
+	const inputRef = useRef<HTMLTextAreaElement>(null)
+	const containerRef = useRef<HTMLDivElement>(null)
+
+	useEffect(() => {
+		const onFullscreenChange = () => {
+			setIsFullscreen(!!document.fullscreenElement)
+		}
+		document.addEventListener('fullscreenchange', onFullscreenChange)
+		return () => document.removeEventListener('fullscreenchange', onFullscreenChange)
+	}, [])
+
+	function toggleFullscreen() {
+		if (!document.fullscreenElement) {
+			containerRef.current?.requestFullscreen()
+		} else {
+			document.exitFullscreen()
+		}
+	}
+
+	function handleClear() {
+		setText('')
+		inputRef.current?.focus()
+	}
+
+	function handlePhraseClick(phrase: string) {
+		setText(phrase)
+		inputRef.current?.focus()
+	}
+
+	const bg = darkMode ? 'bg-gray-950' : 'bg-white'
+	const textColor = darkMode ? 'text-white' : 'text-gray-900'
+	const borderColor = darkMode ? 'border-gray-700' : 'border-gray-200'
+	const subTextColor = darkMode ? 'text-gray-400' : 'text-gray-500'
+	const inputBg = darkMode ? 'bg-gray-900 text-white placeholder-gray-600' : 'bg-gray-50 text-gray-900 placeholder-gray-400'
+	const btnBase = darkMode
+		? 'border border-gray-700 bg-gray-800 text-gray-300 hover:bg-gray-700'
+		: 'border border-gray-200 bg-white text-gray-600 hover:bg-gray-50'
+
+	return (
+		<div
+			ref={containerRef}
+			className={`flex flex-col ${bg} ${isFullscreen ? 'h-screen' : 'min-h-[calc(100vh-120px)]'}`}
+		>
+			{/* Display area */}
+			<div className={`flex-1 flex items-center justify-center px-8 py-10 border-b ${borderColor}`}>
+				{text ? (
+					<p
+						className={`${textColor} leading-tight text-center break-all whitespace-pre-wrap`}
+						style={{ fontSize: `${fontSize}px`, fontWeight: 700, letterSpacing: '-0.01em' }}
+					>
+						{text}
+					</p>
+				) : (
+					<p className={`${subTextColor} text-2xl select-none`}>在下方输入文字…</p>
+				)}
+			</div>
+
+			{/* Controls */}
+			<div className={`shrink-0 ${bg} px-4 pt-4 pb-2 space-y-3`}>
+				{/* Quick phrases */}
+				<div className="flex flex-wrap gap-2">
+					{QUICK_PHRASES.map(phrase => (
+						<button
+							key={phrase}
+							onClick={() => handlePhraseClick(phrase)}
+							className={`px-3 py-1.5 text-sm font-medium transition-colors ${btnBase}`}
+							style={{ borderRadius: '2px' }}
+						>
+							{phrase}
+						</button>
+					))}
+				</div>
+
+				{/* Text input */}
+				<textarea
+					ref={inputRef}
+					value={text}
+					onChange={e => setText(e.target.value)}
+					placeholder="输入文字，上方实时大字展示"
+					rows={2}
+					autoFocus
+					className={`w-full px-4 py-3 text-xl border ${borderColor} ${inputBg} resize-none focus:outline-none focus:ring-2 focus:ring-blue-500`}
+					style={{ borderRadius: '2px' }}
+				/>
+
+				{/* Toolbar */}
+				<div className="flex items-center gap-2 pb-3 flex-wrap">
+					{/* Font size */}
+					<div className="flex items-center gap-1">
+						{FONT_SIZES.map(size => (
+							<button
+								key={size}
+								onClick={() => setFontSize(size)}
+								className={`w-8 h-8 text-xs font-bold transition-colors ${
+									fontSize === size
+										? 'bg-blue-600 text-white border border-blue-600'
+										: btnBase
+								}`}
+								style={{ borderRadius: '2px' }}
+								title={`字号 ${size}px`}
+							>
+								{size / 40}
+							</button>
+						))}
+					</div>
+
+					<div className="flex-1" />
+
+					{/* Clear */}
+					<button
+						onClick={handleClear}
+						disabled={!text}
+						className={`px-4 py-1.5 text-sm font-medium transition-colors disabled:opacity-30 ${btnBase}`}
+						style={{ borderRadius: '2px' }}
+					>
+						清空
+					</button>
+
+					{/* Dark mode toggle */}
+					<button
+						onClick={() => setDarkMode(d => !d)}
+						className={`px-3 py-1.5 text-sm transition-colors ${btnBase}`}
+						style={{ borderRadius: '2px' }}
+						title={darkMode ? '切换亮色' : '切换暗色'}
+					>
+						{darkMode ? '☀️' : '🌙'}
+					</button>
+
+					{/* Fullscreen */}
+					<button
+						onClick={toggleFullscreen}
+						className={`px-3 py-1.5 text-sm transition-colors ${btnBase}`}
+						style={{ borderRadius: '2px' }}
+						title={isFullscreen ? '退出全屏' : '全屏展示'}
+					>
+						{isFullscreen ? '⊠' : '⛶'}
+					</button>
+				</div>
+			</div>
+		</div>
+	)
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
新增 `big-text` 工具——大字展示板，入口 `#big-text`。

**功能**
- 输入框实时将文字以大字显示在上方展示区
- 字号五档可选（2×～6×，对应 80px～240px）
- 内置 8 条常用快捷短语（谢谢、请等一下、我需要帮助……），点击直接填入
- 深色 / 浅色主题一键切换（默认深色，深色背景白字对比度更高）
- 全屏按钮，可调用浏览器全屏 API 让展示区占满整个屏幕
- 独占全页面布局（与 markdown-reader 同级），无 padding 干扰

**改动文件**
- `src/tools/big-text/BigTextTool.tsx`（新增）
- `src/data/routes.ts`（注册工具条目 + 页面标题）
- `src/App.tsx`（添加路由 + 全页面逻辑）
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cbfaa5d8-ce14-4baa-90ae-52b8e86ac6e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cbfaa5d8-ce14-4baa-90ae-52b8e86ac6e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

