### PR TITLE
feat(apps): 新增字数统计、批量比例裁剪、AI 图片生成三个独立应用

### DIFF
--- a/apps/batch-cropper/index.html
+++ b/apps/batch-cropper/index.html
@@ -1,0 +1,541 @@
+<!doctype html>
+<html lang="zh-CN">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="theme-color" content="#f7f7f8" />
+  <link rel="icon" type="image/svg+xml"
+    href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0%200%2064%2064'%3E%3Crect width='64' height='64' rx='14' fill='%232563eb'/%3E%3Cpath d='M20%208v36h36M8%2020h36v36' stroke='%23fff' stroke-width='5' fill='none'/%3E%3C/svg%3E" />
+  <title>批量比例裁剪 | Mecha Tools</title>
+  <link rel="stylesheet" href="/src/index.css" />
+  <style>
+    * { box-sizing: border-box; }
+    label { font-weight: bold; margin-right: 5px; display: inline-block; }
+    .input-group {
+      display: flex; flex-wrap: wrap; align-items: center; gap: 12px;
+      background-color: #f9fafb; border: 1px solid #e5e7eb; border-radius: 8px;
+      padding: 12px; margin-bottom: 14px;
+    }
+    input[type="number"], input[type="file"], button, select {
+      padding: 8px 10px; border-radius: 6px; border: 1px solid #ccc; vertical-align: middle;
+    }
+    input[type="number"] { width: 70px; }
+    button { cursor: pointer; transition: background-color 0.2s ease; }
+    button:disabled { background-color: #bdc3c7; cursor: not-allowed; color: #fff; }
+    .preset-button { background-color: #95a5a6; color: #fff; border: none; min-width: 50px; }
+    .preset-button:hover { background-color: #7f8c8d; }
+
+    #processButton { background-color: #2563eb; color: white; border: none; font-weight: bold; }
+    #processButton:hover:not(:disabled) { background-color: #1d4ed8; }
+    #downloadZipButton { background-color: #16a34a; color: white; border: none; font-weight: bold; }
+    #downloadZipButton:hover:not(:disabled) { background-color: #15803d; }
+
+    .previews-container { display: grid; grid-template-columns: repeat(auto-fill, minmax(180px, 1fr)); gap: 15px; margin-top: 10px; }
+    .image-item { border: 1px solid #ddd; padding: 8px; border-radius: 5px; text-align: center; background: #fff; }
+    .image-item img { max-width: 100%; height: auto; border-radius: 3px; }
+    .image-item span { display: block; font-size: 12px; word-break: break-all; margin: 6px 0; color: #555; }
+    .image-item a { color: #2563eb; text-decoration: none; font-size: 13px; }
+    .image-item a:hover { text-decoration: underline; }
+
+    .status-message { padding: 10px; border-radius: 5px; margin-top: 10px; }
+    .processing { background-color: #eafaf1; color: #27ae60; }
+    .error-message {
+      color: #c0392b; font-style: italic; margin-top: 5px;
+      background-color: #f9eaea; padding: 5px 10px; border-radius: 3px;
+      display: block; margin-bottom: 10px;
+    }
+    #zipProgress { margin-top: 10px; font-style: italic; color: #3498db; }
+  </style>
+</head>
+
+<body class="min-h-screen bg-mech-bg text-mech-text antialiased">
+  <main class="max-w-4xl mx-auto px-4 py-8 space-y-6">
+    <header class="sticky top-0 z-30 border-b border-mech-edge/70 backdrop-blur bg-mech-bg/70 -mx-4 px-4 py-3">
+      <div class="flex items-center justify-between">
+        <a class="font-semibold tracking-wider hover:text-black" href="/">Mecha Tools</a>
+        <a class="inline-flex items-center gap-2 px-3 py-2 rounded-md border border-mech-edge bg-white hover:bg-neutral-50 text-mech-text transition-colors" href="/">返回首页</a>
+      </div>
+    </header>
+
+    <section class="bg-mech-panel border border-mech-edge rounded-xl shadow-subtle p-6 space-y-5">
+      <div>
+        <h1 class="text-xl font-semibold tracking-wide">批量图片比例裁剪器</h1>
+        <p class="text-mech-muted mt-2">选择多个图片文件，设置裁剪参数，程序将对每张图片进行裁剪。您可以单独下载每张图片，或将所有结果打包下载为ZIP文件。</p>
+      </div>
+
+      <div>
+        <div class="input-group">
+          <div>
+            <label for="aspectWidth">裁剪宽高比:</label>
+            <input type="number" id="aspectWidth" placeholder="宽" min="1" step="1"> :
+            <input type="number" id="aspectHeight" placeholder="高" min="1" step="1">
+          </div>
+          <div class="flex flex-wrap gap-2">
+            <button type="button" class="preset-button" data-w="16" data-h="9">16:9</button>
+            <button type="button" class="preset-button" data-w="4" data-h="3">4:3</button>
+            <button type="button" class="preset-button" data-w="1" data-h="1">1:1</button>
+            <button type="button" class="preset-button" data-w="9" data-h="16">9:16 (竖)</button>
+            <button type="button" class="preset-button" data-w="3" data-h="2">3:2</button>
+            <button type="button" class="preset-button" data-w="2" data-h="3">2:3 (竖)</button>
+            <button type="button" id="originalAspectRatioButton" class="preset-button">原图比例</button>
+          </div>
+        </div>
+
+        <div class="input-group">
+          <div>
+            <label for="cropTopPixels">顶部裁剪像素:</label>
+            <input type="number" id="cropTopPixels" value="0" min="0" step="1" title="从图片顶部移除的像素行数">
+          </div>
+          <div>
+            <label for="cropBottomPixels">底部裁剪像素:</label>
+            <input type="number" id="cropBottomPixels" value="0" min="0" step="1" title="从图片底部移除的像素行数">
+          </div>
+          <div>
+            <label for="cropLeftPixels">左侧裁剪像素:</label>
+            <input type="number" id="cropLeftPixels" value="0" min="0" step="1" title="从图片左侧移除的像素列数">
+          </div>
+          <div>
+            <label for="cropRightPixels">右侧裁剪像素:</label>
+            <input type="number" id="cropRightPixels" value="0" min="0" step="1" title="从图片右侧移除的像素列数">
+          </div>
+          <div>
+            <button type="button" id="setDefaultPixelCropButton" class="preset-button">默认边框裁剪 (上64/下96/左0/右0)</button>
+          </div>
+        </div>
+
+        <div class="input-group">
+          <div>
+            <label for="outputFormat">输出格式:</label>
+            <select id="outputFormat">
+              <option value="source">尽量与原图一致 (JPG/PNG)</option>
+              <option value="png">始终输出 PNG</option>
+              <option value="jpeg">始终输出 JPG</option>
+            </select>
+          </div>
+          <div>
+            <label for="jpegQuality">JPG质量 (0.1-1.0):</label>
+            <input type="number" id="jpegQuality" value="0.92" min="0.1" max="1.0" step="0.01" style="width: 70px;">
+          </div>
+        </div>
+      </div>
+
+      <div class="flex flex-wrap items-center gap-3">
+        <input type="file" id="imageFilesInput" multiple accept="image/png, image/jpeg, image/webp, image/gif, image/bmp">
+        <button id="processButton" class="px-4 py-2 rounded-md">处理选中图片</button>
+        <button id="downloadZipButton" class="px-4 py-2 rounded-md" style="display:none;">下载全部 (ZIP)</button>
+      </div>
+
+      <div id="outputArea">
+        <h2 class="text-lg font-semibold mb-2">处理结果预览:</h2>
+        <p id="processingStatus" class="status-message processing" style="display:none;">正在处理图片，请稍候...</p>
+        <p id="zipProgress" style="display:none;"></p>
+        <div id="previewsContainer" class="previews-container"></div>
+      </div>
+    </section>
+  </main>
+
+  <!-- CDN 依赖：版本与 SRI 已钉死（仓库约定），升级时需同步重算摘要 -->
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js"
+    integrity="sha512-XMVd28F1oH/O71fzwBnV7HucLxVwtxf26XV8P4wPk26EDxuGZ91N8bsOttmnomcCD3CS5ZMRL50H0GgOHvegtg=="
+    crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/FileSaver.js/2.0.5/FileSaver.min.js"
+    integrity="sha512-Qlv6VSKh1gDKGoJbnyA5RMXYcvnpIqhO++MhIM2fStMcGT9i2T//tSwYFlcyoRRDcDZ+TYHpH8azBBCyhpSeqw=="
+    crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const imageFilesInput = document.getElementById('imageFilesInput');
+      const processButton = document.getElementById('processButton');
+      const downloadZipButton = document.getElementById('downloadZipButton');
+      const previewsContainer = document.getElementById('previewsContainer');
+      const processingStatus = document.getElementById('processingStatus');
+      const zipProgress = document.getElementById('zipProgress');
+      const aspectWidthInput = document.getElementById('aspectWidth');
+      const aspectHeightInput = document.getElementById('aspectHeight');
+      const outputFormatSelect = document.getElementById('outputFormat');
+      const jpegQualityInput = document.getElementById('jpegQuality');
+      const cropTopPixelsInput = document.getElementById('cropTopPixels');
+      const cropBottomPixelsInput = document.getElementById('cropBottomPixels');
+      const cropLeftPixelsInput = document.getElementById('cropLeftPixels');
+      const cropRightPixelsInput = document.getElementById('cropRightPixels');
+      const setDefaultPixelCropButton = document.getElementById('setDefaultPixelCropButton');
+      const originalAspectRatioButton = document.getElementById('originalAspectRatioButton');
+
+      let processedFilesData = [];
+      let ratioString = 'original';
+      let targetAspectRatio = null;
+
+      // 宽高比预设按钮
+      document.querySelectorAll('.preset-button[data-w]').forEach(button => {
+        button.addEventListener('click', () => {
+          aspectWidthInput.value = button.dataset.w;
+          aspectHeightInput.value = button.dataset.h;
+        });
+      });
+
+      originalAspectRatioButton.addEventListener('click', () => {
+        aspectWidthInput.value = '';
+        aspectHeightInput.value = '';
+      });
+
+      setDefaultPixelCropButton.addEventListener('click', () => {
+        cropTopPixelsInput.value = '64';
+        cropBottomPixelsInput.value = '96';
+        cropLeftPixelsInput.value = '0';
+        cropRightPixelsInput.value = '0';
+      });
+
+      processButton.addEventListener('click', async () => {
+        const files = imageFilesInput.files;
+
+        if (!files || files.length === 0) {
+          alert("请先选择要处理的图片文件。");
+          return;
+        }
+
+        processedFilesData = [];
+        previewsContainer.innerHTML = '';
+
+        targetAspectRatio = null;
+        ratioString = 'original';
+
+        const aspectW_val = aspectWidthInput.value;
+        const aspectH_val = aspectHeightInput.value;
+
+        if (!(aspectW_val === '' && aspectH_val === '')) {
+          if (aspectW_val === '' || aspectH_val === '') {
+            alert("请完整输入宽和高来定义比例，或两者都留空以保持原图比例。");
+            return;
+          }
+          const aspectW = parseInt(aspectW_val);
+          const aspectH = parseInt(aspectH_val);
+          if (isNaN(aspectW) || isNaN(aspectH) || aspectW <= 0 || aspectH <= 0) {
+            alert("无效的宽高比。请输入正整数。");
+            return;
+          }
+          targetAspectRatio = aspectW / aspectH;
+          ratioString = `${aspectW}x${aspectH}`;
+        } else {
+          processingStatus.textContent = '正在准备处理图片...';
+        }
+
+        const cropTop = parseInt(cropTopPixelsInput.value) || 0;
+        const cropBottom = parseInt(cropBottomPixelsInput.value) || 0;
+        const cropLeft = parseInt(cropLeftPixelsInput.value) || 0;
+        const cropRight = parseInt(cropRightPixelsInput.value) || 0;
+        const outputFormat = outputFormatSelect.value;
+        const jpegQuality = parseFloat(jpegQualityInput.value) || 0.92;
+
+        processingStatus.style.display = 'block';
+        processingStatus.textContent = `正在准备处理 ${files.length} 张图片...`;
+        downloadZipButton.style.display = 'none';
+
+        processButton.disabled = true;
+        downloadZipButton.disabled = true;
+        imageFilesInput.disabled = true;
+
+        let successCount = 0;
+        for (let i = 0; i < files.length; i++) {
+          const file = files[i];
+          processingStatus.textContent = `正在处理图片 ${i + 1} / ${files.length}: ${file.name}`;
+          if (!file.type.startsWith('image/')) {
+            displayError(`跳过非图片文件: ${file.name}`);
+            continue;
+          }
+
+          try {
+            const { imageDataUrl, outputFilename } = await cropImageToRatio(
+              file,
+              targetAspectRatio,
+              ratioString,
+              outputFormat,
+              jpegQuality,
+              cropTop,
+              cropBottom,
+              cropLeft,
+              cropRight
+            );
+            processedFilesData.push({ filename: outputFilename, dataUrl: imageDataUrl });
+            displayPreview(imageDataUrl, outputFilename);
+            successCount++;
+          } catch (error) {
+            displayError(`处理文件 ${file.name} 出错: ${error.message}`);
+            console.error(`Error processing ${file.name}:`, error);
+          }
+        }
+
+        processingStatus.textContent = `处理完成！成功处理 ${successCount} / ${files.length} 张图片。`;
+        setTimeout(() => { processingStatus.style.display = 'none'; }, 5000);
+
+        processButton.disabled = false;
+        imageFilesInput.disabled = false;
+        imageFilesInput.value = '';
+
+        if (processedFilesData.length > 0) {
+          downloadZipButton.style.display = 'inline-block';
+          downloadZipButton.disabled = false;
+          downloadZipButton.textContent = `下载全部 (${processedFilesData.length}) ZIP`;
+        }
+      });
+
+      downloadZipButton.addEventListener('click', async () => {
+        if (processedFilesData.length === 0) {
+          alert("没有已处理的文件可供下载。");
+          return;
+        }
+
+        downloadZipButton.textContent = '正在压缩...';
+        downloadZipButton.disabled = true;
+        processButton.disabled = true;
+        zipProgress.textContent = `开始压缩 ${processedFilesData.length} 个文件...`;
+        zipProgress.style.color = '#3498db';
+        zipProgress.style.display = 'block';
+
+        try {
+          if (typeof JSZip === 'undefined') {
+            throw new Error("JSZip library not loaded. Check browser console or adblockers.");
+          }
+          const zip = new JSZip();
+          let filesAddedToZip = 0;
+
+          for (let i = 0; i < processedFilesData.length; i++) {
+            const item = processedFilesData[i];
+            if (!item || !item.dataUrl || !item.filename) {
+              console.warn(`Skipping invalid processed data at index ${i}`);
+              continue;
+            }
+
+            try {
+              const parts = item.dataUrl.split(',');
+              if (parts.length < 2 || !parts[1]) {
+                throw new Error('Invalid data URL format for base64 extraction.');
+              }
+              const base64Data = parts[1];
+              zip.file(item.filename, base64Data, { base64: true });
+              filesAddedToZip++;
+            } catch (zipError) {
+              console.error(`Error adding file ${item.filename} to zip: ${zipError.message}`);
+              displayError(`添加文件 ${item.filename} 到ZIP时出错: ${zipError.message}`);
+              continue;
+            }
+
+            if ((i + 1) % 10 === 0 || i === processedFilesData.length - 1) {
+              zipProgress.textContent = `已添加 ${i + 1} / ${processedFilesData.length} 文件到压缩包...`;
+            }
+          }
+
+          if (filesAddedToZip === 0) {
+            throw new Error("没有文件成功添加到压缩包。可能是由于之前转换错误。");
+          }
+
+          zipProgress.textContent = '正在生成 ZIP 文件...';
+          if (typeof saveAs === 'undefined') {
+            throw new Error("FileSaver library not loaded. Check browser console or adblockers.");
+          }
+
+          const zipBlob = await zip.generateAsync(
+            { type: "blob" },
+            (metadata) => {
+              zipProgress.textContent = `压缩中: ${metadata.percent.toFixed(0)}%`;
+            }
+          );
+
+          const currentRatioStringForZip = (aspectWidthInput.value === '' && aspectHeightInput.value === '') ? "original" : `${aspectWidthInput.value}x${aspectHeightInput.value}`;
+          const timestamp = new Date().toISOString().replace(/[:.]/g, '').slice(0, 15);
+          const zipFilename = `cropped_${currentRatioStringForZip}_${timestamp}.zip`;
+          saveAs(zipBlob, zipFilename);
+
+          zipProgress.textContent = `ZIP 文件 '${zipFilename}' 已生成并开始下载！`;
+          setTimeout(() => { zipProgress.style.display = 'none'; }, 5000);
+
+        } catch (error) {
+          console.error("创建 ZIP 文件出错:", error);
+          zipProgress.textContent = `创建 ZIP 文件失败: ${error.message}`;
+          zipProgress.style.color = '#c0392b';
+          alert(`创建 ZIP 文件失败: ${error.message}`);
+        } finally {
+          downloadZipButton.textContent = `下载全部 (${processedFilesData.length}) ZIP`;
+          downloadZipButton.disabled = false;
+          processButton.disabled = false;
+        }
+      });
+
+      function displayPreview(imageDataUrl, filename) {
+        const itemDiv = document.createElement('div');
+        itemDiv.className = 'image-item';
+
+        const preview = document.createElement('img');
+        preview.src = imageDataUrl;
+        preview.alt = `Preview of ${filename}`;
+        preview.title = filename;
+        preview.loading = 'lazy';
+        itemDiv.appendChild(preview);
+
+        const nameSpan = document.createElement('span');
+        nameSpan.textContent = filename;
+        itemDiv.appendChild(nameSpan);
+
+        const downloadLink = document.createElement('a');
+        downloadLink.href = imageDataUrl;
+        downloadLink.download = filename;
+        downloadLink.textContent = '下载';
+        downloadLink.title = `下载 ${filename}`;
+        itemDiv.appendChild(downloadLink);
+
+        previewsContainer.appendChild(itemDiv);
+      }
+
+      function displayError(message) {
+        const errorMsg = document.createElement('p');
+        errorMsg.textContent = message;
+        errorMsg.className = 'error-message';
+        processingStatus.parentNode.insertBefore(errorMsg, processingStatus.nextSibling);
+      }
+
+      function removeErrors() {
+        processingStatus.parentNode.querySelectorAll('.error-message').forEach((el) => el.remove());
+      }
+
+      async function cropImageToRatio(file, targetAspectRatio, ratioStr, outputFormat = 'source', jpegQuality = 0.92, cropTopPixels = 0, cropBottomPixels = 0, cropLeftPixels = 0, cropRightPixels = 0) {
+        return new Promise((resolve, reject) => {
+          const reader = new FileReader();
+
+          reader.onload = (event) => {
+            if (!event.target || !event.target.result) {
+              return reject(new Error('FileReader did not return a result.'));
+            }
+            const img = new Image();
+            img.onload = () => {
+              try {
+                const imgOriginalWidth = img.width;
+                const imgOriginalHeight = img.height;
+
+                if (imgOriginalWidth === 0 || imgOriginalHeight === 0) {
+                  return reject(new Error('Image has zero dimensions.'));
+                }
+
+                if (cropTopPixels < 0 || cropBottomPixels < 0 || cropLeftPixels < 0 || cropRightPixels < 0) {
+                  return reject(new Error('裁剪像素值不能为负数。'));
+                }
+                if ((cropTopPixels + cropBottomPixels) >= imgOriginalHeight) {
+                  return reject(new Error(`顶部和底部裁剪的总和 (${cropTopPixels + cropBottomPixels}px) 大于或等于图片高度 (${imgOriginalHeight}px)。`));
+                }
+                if ((cropLeftPixels + cropRightPixels) >= imgOriginalWidth) {
+                  return reject(new Error(`左侧和右侧裁剪的总和 (${cropLeftPixels + cropRightPixels}px) 大于或等于图片宽度 (${imgOriginalWidth}px)。`));
+                }
+
+                const effectiveSourceX = cropLeftPixels;
+                const effectiveSourceY = cropTopPixels;
+                const effectiveWidthForAspectRatio = imgOriginalWidth - cropLeftPixels - cropRightPixels;
+                const effectiveHeightForAspectRatio = imgOriginalHeight - cropTopPixels - cropBottomPixels;
+
+                if (effectiveWidthForAspectRatio <= 0 || effectiveHeightForAspectRatio <= 0) {
+                  return reject(new Error('应用像素裁剪后图片尺寸无效。'));
+                }
+
+                let finalCropWidth = effectiveWidthForAspectRatio;
+                let finalCropHeight = effectiveHeightForAspectRatio;
+                let aspectCropXOffset = 0;
+                let aspectCropYOffset = 0;
+
+                if (targetAspectRatio !== null) {
+                  const currentEffectiveAspectRatio = effectiveWidthForAspectRatio / effectiveHeightForAspectRatio;
+                  if (Math.abs(currentEffectiveAspectRatio - targetAspectRatio) > 0.001) {
+                    if (currentEffectiveAspectRatio > targetAspectRatio) {
+                      finalCropWidth = effectiveHeightForAspectRatio * targetAspectRatio;
+                      aspectCropXOffset = (effectiveWidthForAspectRatio - finalCropWidth) / 2;
+                    } else {
+                      finalCropHeight = effectiveWidthForAspectRatio / targetAspectRatio;
+                      aspectCropYOffset = (effectiveHeightForAspectRatio - finalCropHeight) / 2;
+                    }
+                  }
+                }
+
+                finalCropWidth = Math.max(1, Math.round(finalCropWidth));
+                finalCropHeight = Math.max(1, Math.round(finalCropHeight));
+
+                const canvas = document.createElement('canvas');
+                canvas.width = finalCropWidth;
+                canvas.height = finalCropHeight;
+
+                const ctx = canvas.getContext('2d');
+                if (!ctx) {
+                  return reject(new Error('无法获取 Canvas Context。'));
+                }
+
+                ctx.drawImage(
+                  img,
+                  Math.round(effectiveSourceX + aspectCropXOffset), Math.round(effectiveSourceY + aspectCropYOffset),
+                  finalCropWidth, finalCropHeight,
+                  0, 0,
+                  canvas.width, canvas.height
+                );
+
+                const lastDotIndex = file.name.lastIndexOf('.');
+                let baseName = file.name;
+                let originalExtension = '';
+
+                if (lastDotIndex > 0 && lastDotIndex < file.name.length - 1) {
+                  baseName = file.name.substring(0, lastDotIndex);
+                  originalExtension = file.name.substring(lastDotIndex + 1).toLowerCase();
+                }
+
+                let outputMimeType = 'image/png';
+                let outputExtension = 'png';
+                let quality = undefined;
+
+                if (outputFormat === 'jpeg') {
+                  outputMimeType = 'image/jpeg';
+                  outputExtension = 'jpeg';
+                  quality = jpegQuality;
+                } else if (outputFormat === 'png') {
+                  outputMimeType = 'image/png';
+                  outputExtension = 'png';
+                } else {
+                  if (originalExtension === 'jpg' || originalExtension === 'jpeg') {
+                    outputMimeType = 'image/jpeg';
+                    outputExtension = 'jpeg';
+                    quality = jpegQuality;
+                  } else {
+                    outputMimeType = 'image/png';
+                    outputExtension = 'png';
+                  }
+                }
+                const outputFilename = `${baseName}_cropped_${ratioStr}.${outputExtension}`;
+                const imageDataUrl = quality !== undefined ? canvas.toDataURL(outputMimeType, quality) : canvas.toDataURL(outputMimeType);
+
+                if (!imageDataUrl || imageDataUrl === 'data:,') {
+                  throw new Error('Generated empty image data.');
+                }
+
+                resolve({ imageDataUrl, outputFilename });
+
+              } catch (error) {
+                console.error("Error during canvas processing:", error);
+                reject(new Error(`Canvas processing error: ${error.message}`));
+              }
+            };
+            img.onerror = () => {
+              reject(new Error('图片加载失败。文件可能已损坏或格式不受支持。'));
+            };
+            if (typeof event.target.result === 'string') {
+              img.src = event.target.result;
+            } else {
+              reject(new Error('FileReader result is not a string.'));
+            }
+          };
+          reader.onerror = () => {
+            reject(new Error('读取文件失败。'));
+          };
+          reader.readAsDataURL(file);
+        });
+      }
+
+      // 每次开始新一批处理前清掉上一批的错误提示
+      imageFilesInput.addEventListener('change', removeErrors);
+    });
+  </script>
+</body>
+
+</html>

--- a/apps/batch-cropper/meta.json
+++ b/apps/batch-cropper/meta.json
@@ -1,0 +1,7 @@
+{
+  "title": "批量比例裁剪",
+  "description": "批量按宽高比与像素边距裁剪图片，支持格式选择、质量调节与 ZIP 打包下载",
+  "version": "1.0.0",
+  "updatedAt": "2026-08-22",
+  "tags": ["image", "crop", "batch", "zip"]
+}

--- a/apps/image-generator/index.html
+++ b/apps/image-generator/index.html
@@ -1,0 +1,249 @@
+<!doctype html>
+<html lang="zh-CN">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="theme-color" content="#f7f7f8" />
+  <link rel="icon" type="image/svg+xml"
+    href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0%200%2064%2064'%3E%3Crect width='64' height='64' rx='14' fill='%23007bff'/%3E%3Ccircle cx='26' cy='26' r='9' fill='%23ffd54d'/%3E%3Cpath d='M14 50c4-10 10-14 18-14s14 4 18 14z' fill='%23fff'/%3E%3C/svg%3E" />
+  <title>AI 图片生成 | Mecha Tools</title>
+  <link rel="stylesheet" href="/src/index.css" />
+  <style>
+    * { box-sizing: border-box; }
+    .controls { display: flex; flex-direction: column; gap: 15px; }
+    textarea {
+      width: 100%; padding: 10px; border-radius: 6px; border: 1px solid #dee2e6;
+      font-size: 16px; min-height: 80px; resize: vertical;
+    }
+    .size-controls { display: flex; justify-content: space-between; align-items: center; gap: 10px; }
+    .size-controls .input-group { display: flex; align-items: center; gap: 5px; }
+    .size-controls label { font-weight: bold; }
+    .size-controls input[type="number"] { width: 70px; padding: 8px; border-radius: 4px; border: 1px solid #dee2e6; font-size: 14px; }
+
+    .preset-sizes { display: flex; justify-content: center; gap: 10px; flex-wrap: wrap; }
+    .preset-sizes button {
+      background-color: #6c757d; color: white; border: none;
+      padding: 6px 12px; font-size: 12px; border-radius: 15px;
+      cursor: pointer; transition: background-color 0.3s ease;
+    }
+    .preset-sizes button:hover { background-color: #5a6268; }
+
+    .main-buttons { display: flex; gap: 12px; justify-content: center; }
+    .main-buttons button {
+      padding: 12px 25px; font-size: 16px; border: none;
+      border-radius: 6px; cursor: pointer; transition: all 0.3s ease; font-weight: bold;
+    }
+    #generateBtn { background-color: #007bff; color: white; }
+    #generateBtn:hover:not(:disabled) { background-color: #0056b3; }
+    #generateBtn:disabled { background-color: #a0c7ff; cursor: not-allowed; }
+    #downloadBtn { background-color: #28a745; color: white; }
+    #downloadBtn:hover { background-color: #1e7e34; }
+
+    #image-container {
+      margin-top: 20px; min-height: 300px; border: 2px dashed #ced4da;
+      border-radius: 8px; display: flex; justify-content: center; align-items: center; padding: 10px;
+    }
+    #result-image { max-width: 100%; max-height: 500px; border-radius: 4px; box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15); display: none; }
+    #error-message { color: #dc3545; margin-top: 15px; font-weight: bold; }
+    .hidden { display: none !important; }
+
+    .loader {
+      border: 6px solid #f3f3f3; border-top: 6px solid #007bff;
+      border-radius: 50%; width: 50px; height: 50px;
+      animation: spin 1s linear infinite; display: none;
+    }
+    @keyframes spin { 100% { transform: rotate(360deg); } }
+  </style>
+</head>
+
+<body class="min-h-screen bg-mech-bg text-mech-text antialiased">
+  <main class="max-w-2xl mx-auto px-4 py-8 space-y-6">
+    <header class="sticky top-0 z-30 border-b border-mech-edge/70 backdrop-blur bg-mech-bg/70 -mx-4 px-4 py-3">
+      <div class="flex items-center justify-between">
+        <a class="font-semibold tracking-wider hover:text-black" href="/">Mecha Tools</a>
+        <a class="inline-flex items-center gap-2 px-3 py-2 rounded-md border border-mech-edge bg-white hover:bg-neutral-50 text-mech-text transition-colors" href="/">返回首页</a>
+      </div>
+    </header>
+
+    <section class="bg-mech-panel border border-mech-edge rounded-xl shadow-subtle p-6 space-y-5">
+      <div>
+        <h1 class="text-xl font-semibold tracking-wide">AI 图片生成器</h1>
+        <p class="text-mech-muted mt-2">输入你的创意提示词，选择合适的尺寸，让AI为你绘图！</p>
+      </div>
+
+      <div class="controls">
+        <textarea id="prompt-input"
+          placeholder="例如：A cute cat wearing a tiny wizard hat, fantasy art style (一只戴着小巫师帽的可爱猫咪，奇幻艺术风格)"></textarea>
+
+        <div class="size-controls">
+          <div class="input-group">
+            <label for="width-input">宽度:</label>
+            <input type="number" id="width-input" value="1024">
+          </div>
+          <div class="input-group">
+            <label for="height-input">高度:</label>
+            <input type="number" id="height-input" value="1024">
+          </div>
+        </div>
+
+        <div class="preset-sizes">
+          <button data-width="1024" data-height="1024">正方形 (1:1)</button>
+          <button data-width="768" data-height="1366">竖屏 (9:16)</button>
+          <button data-width="1366" data-height="768">横屏 (16:9)</button>
+        </div>
+
+        <div class="main-buttons">
+          <button id="generateBtn">生成图片</button>
+          <button id="downloadBtn" class="hidden">下载图片</button>
+        </div>
+      </div>
+
+      <div id="image-container">
+        <div class="loader" id="loader"></div>
+        <img id="result-image" alt="生成的图片">
+      </div>
+      <p id="error-message" class="hidden"></p>
+    </section>
+  </main>
+
+  <script>
+    // 端点原样迁移自桌面版工具（2025-06）；服务端如有变更后续再修
+    class ImageGenerator {
+      constructor() {
+        this.baseUrl = 'https://image.pollinations.ai';
+      }
+
+      generateImageUrl(prompt, width = 1024, height = 1024) {
+        // 生成随机种子
+        const seed = Math.floor(Math.random() * 1000000000) + 1;
+
+        // 构建URL
+        const imageUrl = `${this.baseUrl}/prompt/${encodeURIComponent(prompt)}?width=${width}&height=${height}&seed=${seed}&nologo=true&model=flux`;
+
+        // 记录生成信息到控制台
+        console.log(`生成图片 - ${new Date().toLocaleString()}`, {
+          prompt,
+          width,
+          height,
+          seed,
+          url: imageUrl
+        });
+
+        return imageUrl;
+      }
+    }
+
+    // --- 应用逻辑 ---
+
+    const generateBtn = document.getElementById('generateBtn');
+    const downloadBtn = document.getElementById('downloadBtn');
+    const promptInput = document.getElementById('prompt-input');
+    const widthInput = document.getElementById('width-input');
+    const heightInput = document.getElementById('height-input');
+    const resultImage = document.getElementById('result-image');
+    const loader = document.getElementById('loader');
+    const errorMessage = document.getElementById('error-message');
+    const presetButtons = document.querySelectorAll('.preset-sizes button');
+
+    const generator = new ImageGenerator();
+
+    // “生成图片”按钮的点击事件
+    generateBtn.addEventListener('click', () => {
+      const prompt = promptInput.value;
+      if (!prompt) {
+        showError('提示词不能为空！');
+        return;
+      }
+
+      const width = parseInt(widthInput.value, 10) || 1024;
+      const height = parseInt(heightInput.value, 10) || 1024;
+
+      // 重置UI状态
+      showError('');
+      generateBtn.disabled = true;
+      generateBtn.textContent = '生成中...';
+      loader.style.display = 'block';
+      resultImage.style.display = 'none';
+      downloadBtn.classList.add('hidden');
+
+      // 生成图片URL并设置给img标签
+      const imageUrl = generator.generateImageUrl(prompt, width, height);
+      resultImage.src = imageUrl;
+    });
+
+    // 图片加载成功时的处理
+    resultImage.onload = () => {
+      loader.style.display = 'none';
+      resultImage.style.display = 'block';
+      downloadBtn.classList.remove('hidden');
+      generateBtn.disabled = false;
+      generateBtn.textContent = '生成新图片';
+    };
+
+    // 图片加载失败时的处理
+    resultImage.onerror = () => {
+      showError('图片加载失败。可能是网络问题或API服务暂时不可用。');
+      loader.style.display = 'none';
+      generateBtn.disabled = false;
+      generateBtn.textContent = '重新生成';
+    };
+
+    // “下载图片”按钮的点击事件
+    downloadBtn.addEventListener('click', async () => {
+      try {
+        // 使用fetch获取图片数据，因为直接下载跨域图片会被浏览器阻止
+        const response = await fetch(resultImage.src);
+        if (!response.ok) {
+          throw new Error('网络响应不正常');
+        }
+        const blob = await response.blob();
+
+        // 创建一个临时的URL指向该Blob对象
+        const blobUrl = URL.createObjectURL(blob);
+
+        // 创建一个临时的a标签用于下载
+        const link = document.createElement('a');
+        link.href = blobUrl;
+        // 从Prompt中提取一个合适的文件名
+        const filename = promptInput.value.trim().slice(0, 30).replace(/[^a-z0-9]/gi, '_').toLowerCase() || 'generated_image';
+        link.download = `${filename}.png`;
+
+        // 触发点击，然后移除
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+
+        // 释放Blob URL占用的内存
+        URL.revokeObjectURL(blobUrl);
+
+      } catch (error) {
+        console.error('下载失败:', error);
+        // 如果fetch失败（通常是CORS策略），则提示用户手动下载
+        alert('自动下载失败！请右键点击图片，然后选择“图片另存为...”来手动保存。');
+      }
+    });
+
+    // 为预设尺寸按钮添加事件监听
+    presetButtons.forEach(button => {
+      button.addEventListener('click', () => {
+        const width = button.dataset.width;
+        const height = button.dataset.height;
+        widthInput.value = width;
+        heightInput.value = height;
+      });
+    });
+
+    // 显示错误信息的函数
+    function showError(message) {
+      errorMessage.textContent = message;
+      if (message) {
+        errorMessage.classList.remove('hidden');
+      } else {
+        errorMessage.classList.add('hidden');
+      }
+    }
+  </script>
+</body>
+
+</html>

--- a/apps/image-generator/meta.json
+++ b/apps/image-generator/meta.json
@@ -1,0 +1,7 @@
+{
+  "title": "AI 图片生成",
+  "description": "输入提示词与尺寸，调用 Pollinations AI 生成图片并可下载",
+  "version": "1.0.0",
+  "updatedAt": "2026-08-22",
+  "tags": ["image", "ai", "generate", "pollinations"]
+}

--- a/apps/word-count/index.html
+++ b/apps/word-count/index.html
@@ -1,0 +1,151 @@
+<!doctype html>
+<html lang="zh-CN">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="theme-color" content="#f7f7f8" />
+  <link rel="icon" type="image/svg+xml"
+    href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0%200%2064%2064'%3E%3Crect width='64' height='64' rx='14' fill='%2316a34a'/%3E%3Ctext x='32' y='44' text-anchor='middle' font-family='Arial%2C Helvetica%2C sans-serif' font-size='32' font-weight='800' fill='%23fff'%3E%E5%AD%97%3C/text%3E%3C/svg%3E" />
+  <title>字数统计 | Mecha Tools</title>
+  <link rel="stylesheet" href="/src/index.css" />
+  <style>
+    * { box-sizing: border-box; }
+    body { font-family: 'Microsoft YaHei', Arial, sans-serif; }
+    textarea { width: 100%; height: 200px; padding: 10px; border: 1px solid #ddd; border-radius: 5px; resize: vertical; font-size: 16px; }
+    .buttons { display: flex; justify-content: space-between; margin-bottom: 20px; gap: 10px; }
+    .stats { display: grid; grid-template-columns: repeat(auto-fill, minmax(150px, 1fr)); gap: 15px; }
+    .stat-card { background-color: #f9f9f9; border-radius: 5px; padding: 15px; text-align: center; box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1); }
+    .stat-value { font-size: 24px; font-weight: bold; color: #16a34a; margin: 5px 0; }
+    .stat-label { font-size: 14px; color: #666; }
+
+    @media (max-width: 600px) {
+      .buttons { flex-direction: column; }
+      .buttons button { width: 100%; }
+    }
+  </style>
+</head>
+
+<body class="min-h-screen bg-mech-bg text-mech-text antialiased">
+  <main class="max-w-3xl mx-auto px-4 py-8 space-y-6">
+    <header class="sticky top-0 z-30 border-b border-mech-edge/70 backdrop-blur bg-mech-bg/70 -mx-4 px-4 py-3">
+      <div class="flex items-center justify-between">
+        <a class="font-semibold tracking-wider hover:text-black" href="/">Mecha Tools</a>
+        <a class="inline-flex items-center gap-2 px-3 py-2 rounded-md border border-mech-edge bg-white hover:bg-neutral-50 text-mech-text transition-colors" href="/">返回首页</a>
+      </div>
+    </header>
+
+    <section class="bg-mech-panel border border-mech-edge rounded-xl shadow-subtle p-6 space-y-5">
+      <h1 class="text-xl font-semibold tracking-wide">文本字数统计工具</h1>
+
+      <div class="input-area">
+        <textarea id="textInput" placeholder="请在此输入或粘贴要统计的文本..."></textarea>
+      </div>
+
+      <div class="buttons">
+        <button id="countBtn" class="px-4 py-2 rounded-md bg-green-600 hover:bg-green-700 text-white transition-colors">统计字数</button>
+        <button id="clearBtn" class="px-4 py-2 rounded-md bg-red-500 hover:bg-red-600 text-white transition-colors">清空文本</button>
+      </div>
+
+      <div class="stats">
+        <div class="stat-card">
+          <div class="stat-label">总字符数</div>
+          <div class="stat-value" id="totalChars">0</div>
+        </div>
+
+        <div class="stat-card">
+          <div class="stat-label">中文字数</div>
+          <div class="stat-value" id="chineseChars">0</div>
+        </div>
+
+        <div class="stat-card">
+          <div class="stat-label">英文单词数</div>
+          <div class="stat-value" id="englishWords">0</div>
+        </div>
+
+        <div class="stat-card">
+          <div class="stat-label">英文字母数</div>
+          <div class="stat-value" id="englishChars">0</div>
+        </div>
+
+        <div class="stat-card">
+          <div class="stat-label">数字字符数</div>
+          <div class="stat-value" id="numberChars">0</div>
+        </div>
+
+        <div class="stat-card">
+          <div class="stat-label">标点符号数</div>
+          <div class="stat-value" id="punctuationChars">0</div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <script>
+    document.addEventListener('DOMContentLoaded', function () {
+      const textInput = document.getElementById('textInput');
+      const countBtn = document.getElementById('countBtn');
+      const clearBtn = document.getElementById('clearBtn');
+
+      // 统计结果显示元素
+      const totalChars = document.getElementById('totalChars');
+      const chineseChars = document.getElementById('chineseChars');
+      const englishWords = document.getElementById('englishWords');
+      const englishChars = document.getElementById('englishChars');
+      const numberChars = document.getElementById('numberChars');
+      const punctuationChars = document.getElementById('punctuationChars');
+
+      // 统计按钮点击事件
+      countBtn.addEventListener('click', function () {
+        const text = textInput.value;
+
+        // 总字符数
+        totalChars.textContent = text.length;
+
+        // 中文字数 (使用Unicode范围匹配中文字符)
+        const chinesePattern = /[\u4e00-\u9fa5]/g;
+        const chineseMatches = text.match(chinesePattern);
+        chineseChars.textContent = chineseMatches ? chineseMatches.length : 0;
+
+        // 英文单词数 (使用空格、标点等分隔英文单词)
+        const wordsPattern = /[a-zA-Z]+/g;
+        const wordsMatches = text.match(wordsPattern);
+        englishWords.textContent = wordsMatches ? wordsMatches.length : 0;
+
+        // 英文字母数
+        const englishPattern = /[a-zA-Z]/g;
+        const englishMatches = text.match(englishPattern);
+        englishChars.textContent = englishMatches ? englishMatches.length : 0;
+
+        // 数字字符数
+        const numberPattern = /[0-9]/g;
+        const numberMatches = text.match(numberPattern);
+        numberChars.textContent = numberMatches ? numberMatches.length : 0;
+
+        // 标点符号数 (包括中英文标点)
+        const punctuationPattern = /[!"#$%&'()*+,-./:;<=>?@[\\\]^_`{|}~，。、；：？！…—·「」『』（）【】《》""'']/g;
+        const punctuationMatches = text.match(punctuationPattern);
+        punctuationChars.textContent = punctuationMatches ? punctuationMatches.length : 0;
+      });
+
+      // 清空按钮点击事件
+      clearBtn.addEventListener('click', function () {
+        textInput.value = '';
+        totalChars.textContent = '0';
+        chineseChars.textContent = '0';
+        englishWords.textContent = '0';
+        englishChars.textContent = '0';
+        numberChars.textContent = '0';
+        punctuationChars.textContent = '0';
+      });
+
+      // 文本输入实时统计（可选功能）
+      textInput.addEventListener('input', function () {
+        // 如果想要实时统计，可以在这里调用统计函数
+        // 为了性能考虑，这里没有实现实时统计
+      });
+    });
+  </script>
+</body>
+
+</html>

--- a/apps/word-count/meta.json
+++ b/apps/word-count/meta.json
@@ -1,0 +1,7 @@
+{
+  "title": "字数统计",
+  "description": "统计文本的总字符数、中文字数、英文单词/字母数、数字与标点符号数",
+  "version": "1.0.0",
+  "updatedAt": "2026-08-22",
+  "tags": ["text", "word-count", "counter", "中文"]
+}


### PR DESCRIPTION
自桌面工具文件夹迁移进仓库：
- apps/word-count: 文本字数统计（总字符/中文/英文单词/字母/数字/标点）
- apps/batch-cropper: 批量按宽高比与像素边距裁剪图片，ZIP 打包下载 （JSZip 3.10.1 / FileSaver.js 2.0.5 CDN，已钉版本并附 SRI）
- apps/image-generator: AI 生图（Pollinations 端点原样迁移，后续再修）

image-to-webp 已有 React 工具覆盖，未重复移植。